### PR TITLE
Debian init script does not have status command.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,9 +12,15 @@
 #
 class irqbalance::params {
   case $::osfamily {
-    'RedHat', 'Debian': {
+    'Debian': {
       $irqbalance_package = 'irqbalance'
       $irqbalance_service = 'irqbalance'
+      $hasstatus          = false
+    }
+    'RedHat': {
+      $irqbalance_package = 'irqbalance'
+      $irqbalance_service = 'irqbalance'
+      $hasstatus          = true
     }
     default: {
       fail("Module ${module_name} is not supported on ${::operatingsystem}")

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -22,7 +22,7 @@ class irqbalance::service (
 
   service { $irqbalance::params::irqbalance_service:
     ensure     => $ensure,
-    hasstatus  => true,
+    hasstatus  => $irqbalance::params::hasstatus,
     hasrestart => true,
     enable     => $enable,
   }


### PR DESCRIPTION
Hello,

The irqbalance init script in Debian (at least Wheezy) does not have a status command. Here is a fix that works for me.
